### PR TITLE
[Fix] 로그인 시 계정 정보가 업데이트 되지 않는 이슈 해결_King

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -17,8 +17,7 @@ public class GameManager : SingletonBehaviour<GameManager>
         PlayerPrefs.SetString("ID", "user123");
 # endif
 
-        GetRanking = new GetRanking();
-        GetRanking.Init();
+       
     }
 
     public void GetCoin()
@@ -30,5 +29,10 @@ public class GameManager : SingletonBehaviour<GameManager>
     {
         PlatformManager.PlatformMoveSpeed = 0f;
         PlayerHealth.Die();
+    }
+    public void LogInInit()
+    {
+        GetRanking = new GetRanking();
+        GetRanking.Init();
     }
 }

--- a/Assets/Scripts/UIScirpts/InGameUIManager.cs
+++ b/Assets/Scripts/UIScirpts/InGameUIManager.cs
@@ -36,6 +36,8 @@ public class InGameUIManager : MonoBehaviour
 
         GameManager.Instance.PlayerHealth.OnGameOver.RemoveListener(ShowGameOverPanel);
         GameManager.Instance.PlayerHealth.OnGameOver.AddListener(ShowGameOverPanel);
+
+        GameManager.Instance.LogInInit();
     }
 
     private void ResetScore(int newScore)

--- a/Assets/Scripts/Util/GetRanking.cs
+++ b/Assets/Scripts/Util/GetRanking.cs
@@ -37,7 +37,7 @@ public class GetRanking
             _userId = PlayerPrefs.GetString("ID");
             gotUserId = true;
         }
-
+        Debug.Log(_userId);
         return _userId;
     }
 


### PR DESCRIPTION
- GameManager에서 GetRanking.Init이 호출되지 않아 생김.
- LogInInit()을 InGameUIManager의 OnEnable에서 호출함.
- 이슈 번호 : #36 